### PR TITLE
Rename MysqlConfig property, correct fromUri default, and remove redundant code

### DIFF
--- a/src/Internals/Connection.php
+++ b/src/Internals/Connection.php
@@ -52,7 +52,7 @@ use Throwable;
  *
  * @see \Hibla\Mysql\MysqlClient
  */
-class Connection
+final class Connection
 {
     /**
      * @var SplQueue<CommandRequest>

--- a/src/Internals/Connection.php
+++ b/src/Internals/Connection.php
@@ -52,7 +52,7 @@ use Throwable;
  *
  * @see \Hibla\Mysql\MysqlClient
  */
-final class Connection
+class Connection
 {
     /**
      * @var SplQueue<CommandRequest>

--- a/src/Manager/PoolManager.php
+++ b/src/Manager/PoolManager.php
@@ -106,7 +106,7 @@ class PoolManager
 
     private int $activeConnections = 0;
 
-    private MysqlConfig $MysqlConfig;
+    private MysqlConfig $mysqlConfig;
 
     private ?ConnectorInterface $connector;
 
@@ -221,7 +221,7 @@ class PoolManager
             $params = $params->withQueryCancellation($enableServerSideCancellation);
         }
 
-        $this->MysqlConfig = $params;
+        $this->mysqlConfig = $params;
 
         if ($maxSize <= 0) {
             throw new InvalidArgumentException('Pool max size must be greater than 0');
@@ -306,10 +306,10 @@ class PoolManager
                 'acquire_timeout' => $this->acquireTimeout,
                 'config_validated' => $this->configValidated,
                 'tracked_connections' => \count($this->connectionCreatedAt),
-                'query_cancellation_enabled' => $this->MysqlConfig->enableServerSideCancellation,
-                'compression_enabled' => $this->MysqlConfig->compress,
-                'reset_connection_enabled' => $this->MysqlConfig->resetConnection,
-                'multi_statements_enabled' => $this->MysqlConfig->multiStatements,
+                'query_cancellation_enabled' => $this->mysqlConfig->enableServerSideCancellation,
+                'compression_enabled' => $this->mysqlConfig->compress,
+                'reset_connection_enabled' => $this->mysqlConfig->resetConnection,
+                'multi_statements_enabled' => $this->mysqlConfig->multiStatements,
                 'on_connect_hook' => $this->onConnect !== null,
                 'is_graceful_shutdown' => $this->isGracefulShutdown,
             ];
@@ -451,7 +451,7 @@ class PoolManager
         }
 
         // 2. Perform connection state reset if enabled.
-        if ($this->MysqlConfig->resetConnection) {
+        if ($this->mysqlConfig->resetConnection) {
             $this->resetAndRelease($connection);
 
             return;
@@ -650,32 +650,26 @@ class PoolManager
             ;
         }
 
+        $drainTempQueue = function () use ($tempQueue): void {
+            while (! $tempQueue->isEmpty()) {
+                $conn = $tempQueue->dequeue();
+
+                if ($this->isClosing || $this->isGracefulShutdown) {
+                    $this->removeConnection($conn);
+                } else {
+                    $this->pool->enqueue($conn);
+                }
+            }
+        };
+
         Promise::all($checkPromises)
             ->then(
-                function () use ($promise, $tempQueue, &$stats): void {
-                    while (! $tempQueue->isEmpty()) {
-                        $conn = $tempQueue->dequeue();
-
-                        if ($this->isClosing || $this->isGracefulShutdown) {
-                            $this->removeConnection($conn);
-                        } else {
-                            $this->pool->enqueue($conn);
-                        }
-                    }
-
+                function () use ($promise, $drainTempQueue, &$stats): void {
+                    $drainTempQueue();
                     $promise->resolve($stats);
                 },
-                function (Throwable $e) use ($promise, $tempQueue): void {
-                    while (! $tempQueue->isEmpty()) {
-                        $conn = $tempQueue->dequeue();
-
-                        if ($this->isClosing || $this->isGracefulShutdown) {
-                            $this->removeConnection($conn);
-                        } else {
-                            $this->pool->enqueue($conn);
-                        }
-                    }
-
+                function (Throwable $e) use ($promise, $drainTempQueue): void {
+                    $drainTempQueue();
                     $promise->reject($e);
                 }
             )
@@ -723,7 +717,6 @@ class PoolManager
         }
 
         // All in-flight work has settled. Clear state and signal completion.
-        $this->activeConnections = 0;
         $this->connectionLastUsed = [];
         $this->connectionCreatedAt = [];
 
@@ -791,7 +784,7 @@ class PoolManager
                     // Mark active again for releaseClean or reset logic.
                     $this->activeConnectionsMap[$connId] = $connection;
 
-                    if ($this->MysqlConfig->resetConnection) {
+                    if ($this->mysqlConfig->resetConnection) {
                         $this->resetAndRelease($connection);
                     } else {
                         $this->releaseClean($connection);
@@ -820,7 +813,7 @@ class PoolManager
 
                     $this->activeConnectionsMap[$connId] = $connection;
 
-                    if ($this->MysqlConfig->resetConnection) {
+                    if ($this->mysqlConfig->resetConnection) {
                         $this->resetAndRelease($connection);
                     } else {
                         $this->releaseClean($connection);
@@ -899,10 +892,6 @@ class PoolManager
 
         // ALWAYS try to serve existing waiters first, even during shutdown!
         $waiter = $this->dequeueActiveWaiter();
-
-        if ($this->waiters->isEmpty()) {
-            $this->waiters = new SplQueue();
-        }
 
         if ($waiter !== null) {
             $connection->resume();
@@ -987,12 +976,6 @@ class PoolManager
      *
      * @return Promise<MysqlConnection>
      */
-    /**
-     * Creates a new connection and resolves the returned promise on success.
-     * Runs the onConnect hook before handing the connection to the caller.
-     *
-     * @return Promise<MysqlConnection>
-     */
     private function createNewConnection(): Promise
     {
         $this->activeConnections++;
@@ -1000,7 +983,7 @@ class PoolManager
         /** @var Promise<MysqlConnection> $promise */
         $promise = new Promise();
 
-        MysqlConnection::create($this->MysqlConfig, $this->connector)
+        MysqlConnection::create($this->mysqlConfig, $this->connector)
             ->then(
                 function (MysqlConnection $connection) use ($promise): void {
                     // Abort immediately if the pool was force-closed mid-handshake
@@ -1068,7 +1051,7 @@ class PoolManager
 
         $this->activeConnections++;
 
-        MysqlConnection::create($this->MysqlConfig, $this->connector)
+        MysqlConnection::create($this->mysqlConfig, $this->connector)
             ->then(
                 function (MysqlConnection $connection) use ($waiter): void {
                     if ($this->isClosing) {

--- a/src/ValueObjects/MysqlConfig.php
+++ b/src/ValueObjects/MysqlConfig.php
@@ -195,7 +195,7 @@ final readonly class MysqlConfig
 
         $enableServerSideCancellation = isset($query['enable_server_side_cancellation'])
             ? filter_var($query['enable_server_side_cancellation'], FILTER_VALIDATE_BOOLEAN)
-            : true;
+            : false;
 
         $compress = isset($query['compress'])
             ? filter_var($query['compress'], FILTER_VALIDATE_BOOLEAN)

--- a/tests/Unit/MysqlConfigTest.php
+++ b/tests/Unit/MysqlConfigTest.php
@@ -129,6 +129,12 @@ describe('MysqlConfig', function (): void {
                 ->and($config->enableServerSideCancellation)->toBeFalse()
             ;
         });
+
+        it('defaults enableServerSideCancellation to false when absent from URI', function (): void {
+            $config = MysqlConfig::fromUri('mysql://localhost/mydb');
+
+            expect($config->enableServerSideCancellation)->toBeFalse();
+        });
     });
 
     describe('Helpers and Logic', function (): void {


### PR DESCRIPTION
Closes #5

Six of the seven approved changes from the issue. Point 8 (adding `final` to `Connection`) is not included - `Mockery::mock(Connection::class)` in `tests/Pest.php` requires subclassing to build the test double and `final` blocks that. It needs an interface extraction before it can land.

- `MysqlConfig::fromUri()` was defaulting `enableServerSideCancellation` to `true`, inconsistent with the constructor and `fromArray()` which both default to `false`. Corrected.
- Removed an unnecessary `new SplQueue()` allocation in `releaseClean()` that replaced the existing queue object when it was already empty.
- Removed a redundant `$this->activeConnections = 0` in `checkShutdownComplete()`. Active connections are already zero at that point.
- Renamed the `$MysqlConfig` property on `PoolManager` to `$mysqlConfig` to match PSR naming.
- Removed a duplicate docblock above `createNewConnection()`.
- Extracted the repeated queue-drain loop in `healthCheck()` into a single closure shared by both the resolve and reject callbacks.
- Added a unit test covering the `fromUri()` default correction.
